### PR TITLE
Update Cavasik runtime to 46

### DIFF
--- a/fix_appdata.patch
+++ b/fix_appdata.patch
@@ -1,0 +1,33 @@
+From a0a90a93de698e87bb221200efa8821f70e05c3e Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Tue, 11 Jun 2024 18:29:25 +0300
+Subject: [PATCH] appdata: Update appdata
+
+- Fix appdata papercuts
+---
+ assets/io.github.TheWisker.Cavasik.metainfo.xml.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/assets/io.github.TheWisker.Cavasik.metainfo.xml.in b/assets/io.github.TheWisker.Cavasik.metainfo.xml.in
+index 90f5c52..643b444 100644
+--- a/assets/io.github.TheWisker.Cavasik.metainfo.xml.in
++++ b/assets/io.github.TheWisker.Cavasik.metainfo.xml.in
+@@ -24,6 +24,7 @@
+   <launchable type="desktop-id">io.github.TheWisker.Cavasik.desktop</launchable>
+   <url type="homepage">https://github.com/TheWisker/Cavasik</url>
+   <url type="bugtracker">https://github.com/TheWisker/Cavasik/issues</url>
++  <url type="vcs-browser">https://github.com/TheWisker/Cavasik</url>
+   <developer_name>TheWisker</developer_name>
+   <translation type="gettext">Cavasik</translation>
+   <screenshots>
+@@ -94,7 +95,6 @@
+     <display_length compare="ge">360</display_length>
+   </requires>
+   <custom>
+-    <value key="Purism::form_factor">workstation</value>
+     <value key="Purism::form_factor">mobile</value>
+   </custom>
+ </component>
+--
+libgit2 1.7.2
+

--- a/io.github.TheWisker.Cavasik.json
+++ b/io.github.TheWisker.Cavasik.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.TheWisker.Cavasik",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "44",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "command" : "cavasik",
     "finish-args" : [

--- a/io.github.TheWisker.Cavasik.json
+++ b/io.github.TheWisker.Cavasik.json
@@ -75,9 +75,9 @@
             "buildsystem" : "meson",
             "sources" : [
                 {
-                    "type" : "git",
-                    "url" : "https://github.com/TheWisker/Cavasik.git",
-                    "commit": "364256db64270c14af641583cf6e2e65df368651"
+                    "type" : "archive",
+                    "url" : "https://github.com/TheWisker/Cavasik/archive/refs/tags/v2.0.1.tar.gz",
+                    "sha256": "c9cd48626a5623a764ebe3844540871634fe5d96cc0f2f7d898ce7ee2482a5ef"
                 }
             ]
 	      }

--- a/io.github.TheWisker.Cavasik.json
+++ b/io.github.TheWisker.Cavasik.json
@@ -78,6 +78,10 @@
                     "type" : "archive",
                     "url" : "https://github.com/TheWisker/Cavasik/archive/refs/tags/v2.0.1.tar.gz",
                     "sha256": "c9cd48626a5623a764ebe3844540871634fe5d96cc0f2f7d898ce7ee2482a5ef"
+                },
+                {
+                    "type" : "patch",
+                    "path": "fix_appdata.patch"
                 }
             ]
 	      }


### PR DESCRIPTION
- Update Cavasik runtime to 46 since runtime version 44 has reached end-of-life.
- Use a specific version of the application.
- Fix appdata papercuts.